### PR TITLE
 Adding peerDependencies allowance for React v16.

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "url": "git+https://github.com/flyingant/react-scroll-to-component.git"
   },
   "peerDependencies": {
-    "react": "^0.14.0 || ^15.0.0",
-    "react-dom": "^0.14.0 || ^15.0.0"
+    "react": "^0.14.0 || ^15.0.0 || ^16.0.0",
+    "react-dom": "^0.14.0 || ^15.0.0 || ^16.0.0"
   },
   "dependencies": {
     "scroll-to": "0.0.2"


### PR DESCRIPTION
Fixes warnings when running `npm install` when React16 is installed.

```
npm WARN react-scroll-to-component@1.0.1 requires a peer of react@^0.14.0 || ^15.0.0 but none is installed. You must install peer dependencies yourself.
npm WARN react-scroll-to-component@1.0.1 requires a peer of react-dom@^0.14.0 || ^15.0.0 but none is installed. You must install peer dependencies yourself.
```